### PR TITLE
Fix mobile header display and create parody with docs site

### DIFF
--- a/amplify-theme/_sass/components/_redesign.scss
+++ b/amplify-theme/_sass/components/_redesign.scss
@@ -112,9 +112,9 @@
     }
 
     @media (max-width: 828px) {
-        display: block;
-        width: 208px;
-        margin: auto;
+        display: flex;
+        width: 46px;
+        margin: 0 auto;
     }
 }
 
@@ -160,7 +160,7 @@
         margin-top: 2px;
 
         @media (max-width: 828px) {
-            margin-top: 1px;
+            display: none;
         }
     }
 

--- a/amplify-theme/_sass/components/_redesign.scss
+++ b/amplify-theme/_sass/components/_redesign.scss
@@ -113,7 +113,7 @@
 
     @media (max-width: 828px) {
         display: flex;
-        width: 46px;
+        width: 64px;
         margin: 0 auto;
     }
 }


### PR DESCRIPTION
Fix mobile header for marketing website

Repro:
- Open aws-amplify.github.io on mobile
- See header text overflow

Creating parody with the docs mobile header:
- https://github.com/aws-amplify/docs/blame/594b745409650abff96b455acb2d0da40bfe74c1/theme/_sass/components/_redesign.scss#L115
- https://github.com/aws-amplify/docs/blame/594b745409650abff96b455acb2d0da40bfe74c1/theme/_sass/components/_redesign.scss#L163