### PR TITLE
Fix spurious broken link report

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -310,3 +310,5 @@ js_libraries:
     url: '?platform=ionic'
   - title: JavaScript
     url: '?platform=purejs'
+
+theme: jekyll-theme-cayman

--- a/_config.yml
+++ b/_config.yml
@@ -310,5 +310,3 @@ js_libraries:
     url: '?platform=ionic'
   - title: JavaScript
     url: '?platform=purejs'
-
-theme: jekyll-theme-cayman

--- a/amplify-theme/_includes/docs-header.html
+++ b/amplify-theme/_includes/docs-header.html
@@ -33,7 +33,7 @@
 				</a>
 			</li>
 			<li>
-				<a href="{% if jekyll.environment == 'production' %}{{ site.amplify.docs_baseurl }}{% endif %}/api">
+				<a href="{% if jekyll.environment == 'production' %}{{ site.amplify.docs_baseurl }}{% endif %}/">
 					API
 				</a>
 			</li>

--- a/amplify-theme/_includes/site-header.html
+++ b/amplify-theme/_includes/site-header.html
@@ -33,7 +33,7 @@
 				</a>
 			</li>
 			<li>
-				<a href="{% if jekyll.environment == 'production' %}{{ site.amplify.docs_baseurl }}{% endif %}/api">
+				<a href="{% if jekyll.environment == 'production' %}{{ site.amplify.docs_baseurl }}{% endif %}/">
 					API
 				</a>
 			</li>


### PR DESCRIPTION
Refiled on behalf of @palpatim 

The following is taken from [his PR](https://github.com/aws-amplify/docs/pull/803) (now copied over to this repo):

Fix spurious broken link report by redirecting anchor of "API" menu to the site
root. This should not affect human users at all, since the anchor only exists
as a hover target to display the language-specific API menu options.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.